### PR TITLE
issue-9: fix possible title utf-8 encoding problems

### DIFF
--- a/iosCertTrustManager.py
+++ b/iosCertTrustManager.py
@@ -651,7 +651,7 @@ class Program:
                 tstore.add_certificate(cert)
             return
         for simulator in ios_simulators():
-            if query_yes_no("Import certificate to " + simulator.title, "no") == "yes":
+            if query_yes_no("Import certificate to " + simulator.title.encode('utf-8'), "no") == "yes":
                 print "Importing to " + simulator.truststore_file
                 tstore = TrustStore(simulator.truststore_file)
                 tstore.add_certificate(cert)


### PR DESCRIPTION
This is fixing an #9  for me, output becomes this and no crash:

```
Import certificate to iPhone X v12.2 [y/N] Importing to /Users/jenkins/Library/Developer/CoreSimulator/Devices/51901893-EEF8-46AA-991C-643E98E0DAD6/data/Library/Keychains/TrustStore.sqlite3
  Existing certificate replaced
Import certificate to iPhone Xʀ v12.2 [y/N] Importing to /Users/jenkins/Library/Developer/CoreSimulator/Devices/8736054F-B0E2-454F-AE3D-96768C687EEA/data/Library/Keychains/TrustStore.sqlite3
  Existing certificate replaced
```