### PR TITLE
Both Python 2/3 compatibility

### DIFF
--- a/iosCertTrustManager.py
+++ b/iosCertTrustManager.py
@@ -33,6 +33,11 @@ import string
 import binascii
 import plistlib
 
+
+if hasattr(__builtins__, 'raw_input'):
+    input = raw_input
+
+
 def query_yes_no(question, default="yes"):
     """Ask a yes/no question via raw_input() and return their answer.
     

--- a/iosCertTrustManager.py
+++ b/iosCertTrustManager.py
@@ -30,7 +30,6 @@ import ssl
 import hashlib
 import subprocess
 import string
-import binascii
 import plistlib
 
 

--- a/iosCertTrustManager.py
+++ b/iosCertTrustManager.py
@@ -393,7 +393,7 @@ class Certificate:
             possl = subprocess.Popen(['openssl',  'x509', '-inform',  'DER',  '-noout',  '-subject', '-nameopt', 'oneline'], 
                 shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=None)
             subjectText, error_text = possl.communicate(self.get_data())
-            return subjectText
+            return subjectText.decode('utf-8')
         return None
 
     def get_subject_ASN1(self):

--- a/iosCertTrustManager.py
+++ b/iosCertTrustManager.py
@@ -38,6 +38,16 @@ if hasattr(__builtins__, 'raw_input'):
     input = raw_input
 
 
+if hasattr(plistlib, 'readPlist'):
+    readPlist = plistlib.readPlist
+else:
+    def readPlist(path_or_file):
+        if isinstance(path_or_file, str):
+            with open(path_or_file, 'rb') as f:
+                return plistlib.load(f)
+        return plistlib.load(path_or_file)
+
+
 def query_yes_no(question, default="yes"):
     """Ask a yes/no question via raw_input() and return their answer.
     
@@ -597,7 +607,7 @@ class Simulator:
         self._is_valid = False
         infofile = simulatordir + "/device.plist"
         if os.path.isfile(infofile):
-            info = plistlib.readPlist(infofile)
+            info = readPlist(infofile)
             runtime = info["runtime"]
             if runtime.startswith(self.runtimeName):
                 self.version = runtime[len(self.runtimeName):].replace("-", ".")
@@ -638,7 +648,7 @@ class DeviceBackup:
         info_plist = self._path + "/Info.plist"
         if os.path.isfile(info_plist):
             try:
-                info = plistlib.readPlist(info_plist)
+                info = readPlist(info_plist)
                 self.device_name = info["Device Name"]
                 self.title = "Backup of " + self.device_name + " - " + str(info["Last Backup Date"])
                 self._isvalid = True

--- a/iosCertTrustManager.py
+++ b/iosCertTrustManager.py
@@ -21,6 +21,7 @@
 # Python-ASN1 is copyright (c) 2007-2008 by Geert Jansen <geert@boskant.nl>. 
 # see https://github.com/geertj/python-asn1
 
+from __future__ import print_function
 import os
 import sys
 import argparse


### PR DESCRIPTION
Recent macOS does not bundle Python 2 but Python 3 so I updated the source code to adapt both Python 2 and 3 interpreter.

Although most changes are automatically generated by 2to3, I manually added some minor changes to improve compatibility.

I tested some basic functionalities like `-l` `-a` `-d` `--dump` in both interpreter (2.7 and 3.11) and confirmed it works well.